### PR TITLE
now you can trust celery🤠😎

### DIFF
--- a/swinTransformer/consumer.py
+++ b/swinTransformer/consumer.py
@@ -20,7 +20,7 @@ class TaskConsumer(AsyncWebsocketConsumer):
         await self.channel_layer.group_discard(self.group_name, self.channel_name)
 
     async def task_update(self, event):
-        message = json.loads(event['message'])
+        message = event['message']
         if message['status'] == 'completed':
             await self.send(text_data=message['result'])
         else:

--- a/swinTransformer/tools/utils.py
+++ b/swinTransformer/tools/utils.py
@@ -33,15 +33,19 @@ def swinTransformerHandler(original_image: str, output_image: str) -> int:
     return result.returncode
 
 
-def inform_channels(task_id: str, content: str):
+async def async_inform_channels(task_id: str, content: str):
     channel_layer = get_channel_layer()
-    async_to_sync(channel_layer.group_send(
+    await channel_layer.group_send(
         settings.CHANNELS_GROUP_NAME_FORMAT.format(task_id=task_id),
         {
             'type': 'task_update',
             'message': {
                 'status': 'completed',
-                'result': content
+                'result': content,
             }
         }
-    ))
+    )
+
+
+def inform_channels(task_id: str, content: str):
+    async_to_sync(async_inform_channels)(task_id, content)


### PR DESCRIPTION
This pull request includes changes to improve the handling of asynchronous tasks and messaging in the `swinTransformer` project. The most important changes include modifying the `task_update` method to directly use the event message and refactoring the `inform_channels` function to support asynchronous execution.

Improvements to asynchronous task handling:

* [`swinTransformer/consumer.py`](diffhunk://#diff-6eaaa20bf07cf4d4d81e11e952c5f894e266efa561e95e60c771475ff9899598L23-R23): Modified the `task_update` method to directly use the event message without parsing it as JSON.

Refactoring for asynchronous execution:

* [`swinTransformer/tools/utils.py`](diffhunk://#diff-0fd3796e176b9eaa45ab200443198984f30c2bd36080dc1709df7b94550d3a1fL36-R51): Refactored the `inform_channels` function to create an asynchronous version `async_inform_channels` and updated the original function to use `async_to_sync` for compatibility.